### PR TITLE
add match_boiler_barrier option to delete lines up-to and including a line matching a regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ source root.
 Remove the `#!/usr/bin/perl`, `use strict;` or `use warnings;` from
 the beginning of your example before inserting them into the POD.
 
+If ["match\_barrier"](#match_barrier) is also set, it instead removes all lines up-to
+and including the line matched by ["match\_barrier"](#match_barrier).
+
+## match\_barrier
+
+A regular expression matching a line indicating the end of
+boilerplate.  This must be used in conjunction with ["remove\_boiler"](#remove_boiler).
+
 ## indent
 
 Specifies the number of spaces to indent by.  This is 1 by default,

--- a/README.md
+++ b/README.md
@@ -66,13 +66,14 @@ source root.
 Remove the `#!/usr/bin/perl`, `use strict;` or `use warnings;` from
 the beginning of your example before inserting them into the POD.
 
-If ["match\_barrier"](#match_barrier) is also set, it instead removes all lines up-to
-and including the line matched by ["match\_barrier"](#match_barrier).
+If ["match\_boiler\_barrier"](#match_boiler_barrier) is also set, it instead removes all lines up-to
+and including the line matched by ["match\_boiler\_barrier"](#match_boiler_barrier).
 
-## match\_barrier
+## match\_boiler\_barrier
 
 A regular expression matching a line indicating the end of
-boilerplate.  This must be used in conjunction with ["remove\_boiler"](#remove_boiler).
+boilerplate.  This option may be used multiple times.
+It must be used in conjunction with ["remove\_boiler"](#remove_boiler).
 
 ## indent
 

--- a/author.yml
+++ b/author.yml
@@ -11,3 +11,4 @@ pod_coverage:
   # for either Class or method.
   private:
     - Dist::Zilla::Plugin::InsertExample#munge_files?
+    - Dist::Zilla::Plugin::InsertExample#mvp_.*

--- a/corpus/DZT4/example/foo.pl
+++ b/corpus/DZT4/example/foo.pl
@@ -1,0 +1,11 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use v5.10;
+
+# BOILERPLATE BARRIER
+
+say 'hello world';
+
+say 'this is an example';

--- a/corpus/DZT4/lib/DZT.pm
+++ b/corpus/DZT4/lib/DZT.pm
@@ -1,0 +1,19 @@
+package DZT;
+
+=head1 NAME
+
+DZT - Dist::Zilla test
+
+=head1 DESCRIPTION
+
+blah blah
+
+=head1 EXAMPLE
+
+here is one example:
+
+# EXAMPLE: example/foo.pl
+
+=cut
+
+1;

--- a/lib/Dist/Zilla/Plugin/InsertExample.pm
+++ b/lib/Dist/Zilla/Plugin/InsertExample.pm
@@ -5,6 +5,10 @@ use 5.020;
 package Dist::Zilla::Plugin::InsertExample {
 
   use Moose;
+
+  use Moose::Util::TypeConstraints;
+  use MooseX::Types::Moose qw(ArrayRef Str RegexpRef);
+
   use Encode qw( encode );
   use List::Util qw( first );
   use experimental qw( signatures postderef );
@@ -67,6 +71,14 @@ source root.
 Remove the C<#!/usr/bin/perl>, C<use strict;> or C<use warnings;> from
 the beginning of your example before inserting them into the POD.
 
+If L</match_boiler_barrier> is also set, it instead removes all lines up-to
+and including the line matched by L</match_boiler_barrier>.
+
+=head2 match_boiler_barrier
+
+A regular expression matching a line indicating the end of
+boilerplate.  This must be used in conjunction with L</remove_boiler>.
+
 =head2 indent
 
 Specifies the number of spaces to indent by.  This is 1 by default,
@@ -83,6 +95,12 @@ and it won't be a verbatim paragraph at all.
   };
 
   has remove_boiler => (is => 'ro', isa => 'Int');
+  {
+      my $type = subtype as RegexpRef;
+      coerce $type, from Str, via {  qr/$_/ };
+      has match_boiler_barrier => ( is => 'ro', isa => $type, coerce => 1, predicate => 'has_match_boiler_barrier' );
+  }
+
   has indent        => (is => 'ro', isa => 'Int', default => 1);
 
   sub munge_files ($self)
@@ -119,17 +137,34 @@ and it won't be a verbatim paragraph at all.
 
     my $indent = ' ' x $self->indent;
 
+    my $in_boiler = 1;
+    my $found_content = 0;
     while(my $line = <$fh>)
     {
       if($self->remove_boiler)
       {
-        next if $line =~ /^\s*$/;
-        next if $line =~ /^#!\/usr\/bin\/perl/;
-        next if $line =~ /^#!\/usr\/bin\/env perl/;
-        next if $line =~ /^use strict;$/;
-        next if $line =~ /^use warnings;$/;
+          if($self->has_match_boiler_barrier)
+          {
+              if($in_boiler)
+              {
+                  $in_boiler = 0 if $line =~ $self->match_boiler_barrier;
+                  next;
+              }
+          }
+          else
+          {
+              next if $line =~ /^\s*$/;
+              next if $line =~ /^#!\/usr\/bin\/perl/;
+              next if $line =~ /^#!\/usr\/bin\/env perl/;
+              next if $line =~ /^use strict;$/;
+              next if $line =~ /^use warnings;$/;
+          }
         return '' if eof $fh;
       }
+      # get rid of any blank lines before the content.
+      next if $line =~ /^\s*$/ && ! $found_content;
+      ++$found_content;
+
       return join "\n", map { "$indent$_" } split /\n/, $line . do { local $/; my $rest = <$fh>; defined $rest ? $rest : '' };
     }
 

--- a/lib/Dist/Zilla/Plugin/InsertExample.pm
+++ b/lib/Dist/Zilla/Plugin/InsertExample.pm
@@ -10,7 +10,7 @@ package Dist::Zilla::Plugin::InsertExample {
   use MooseX::Types::Moose qw(ArrayRef Str RegexpRef);
 
   use Encode qw( encode );
-  use List::Util qw( first );
+  use List::Util qw( first any );
   use experimental qw( signatures postderef );
 
   # ABSTRACT: Insert example into your POD from a file
@@ -148,11 +148,11 @@ and it won't be a verbatim paragraph at all.
     {
       if($self->remove_boiler)
       {
-          if( @{ $self->matches_boiler_barrier } )
+          if( $self->matches_boiler_barrier->@* )
           {
               if($in_boiler)
               {
-                  $in_boiler = 0 if grep $line =~ $_, @{ $self->matches_boiler_barrier };
+                  $in_boiler = 0 if any { $line =~ $_ } $self->matches_boiler_barrier->@*;
                   next;
               }
           }

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -14,6 +14,8 @@ $modules{$_} = $_ for qw(
   Encode
   ExtUtils::MakeMaker
   Moose
+  Moose::Util::TypeConstraints
+  MooseX::Types::Moose
   Test2::V0
 );
 

--- a/t/dist_zilla_plugin_insertexample.t
+++ b/t/dist_zilla_plugin_insertexample.t
@@ -54,7 +54,10 @@ subtest 'remove boiler via barrier' => sub {
         'source/dist.ini' => simple_ini(
           {},
           [ 'GatherDir' => {} ],
-          [ 'InsertExample' => { remove_boiler => 1, match_barrier => 'BARRIER$' } ],
+          [ 'InsertExample' => { remove_boiler => 1,
+                                 match_boiler_barrier => 'BARRIER$',
+                                 match_boiler_barrier => '^# BOILER'
+                                 } ],
         )
       }
     }
@@ -63,7 +66,7 @@ subtest 'remove boiler via barrier' => sub {
   $tzil->build;
 
   my($pm) = grep { $_->name eq 'lib/DZT.pm' } $tzil->files->@*;
-  ok $pm->content !~ m{^ # BOILERPLATE BARRIER;$}m, "module contains example file";
+  ok $pm->content !~ m{BOILERPLATE BARRIER}m, "barrier obeyed";
 };
 
 

--- a/t/dist_zilla_plugin_insertexample.t
+++ b/t/dist_zilla_plugin_insertexample.t
@@ -24,6 +24,49 @@ subtest basics => sub {
   ok $pm->content =~ m{^ say 'hello world';$}m, "module contains example file";
 };
 
+subtest 'remove boiler' => sub {
+
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          {},
+          [ 'GatherDir' => {} ],
+          [ 'InsertExample' => { remove_boiler => 1} ],
+        )
+      }
+    }
+  );
+
+  $tzil->build;
+
+  my($pm) = grep { $_->name eq 'lib/DZT.pm' } $tzil->files->@*;
+  ok $pm->content !~ m{^ use string;$}m, "module contains example file";
+};
+
+subtest 'remove boiler via barrier' => sub {
+
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/DZT4' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          {},
+          [ 'GatherDir' => {} ],
+          [ 'InsertExample' => { remove_boiler => 1, match_barrier => 'BARRIER$' } ],
+        )
+      }
+    }
+  );
+
+  $tzil->build;
+
+  my($pm) = grep { $_->name eq 'lib/DZT.pm' } $tzil->files->@*;
+  ok $pm->content !~ m{^ # BOILERPLATE BARRIER;$}m, "module contains example file";
+};
+
+
 subtest 'basics file not in gather but on disk' => sub {
 
   my $tzil = Builder->from_config(


### PR DESCRIPTION
Sometimes examples have extra boilerplate that doesn't match the built in strings. Examples might require a `use` statement required to pass compilation tests, but which is redundant,. For instance, in
```
use strict;
use warnings;
use Module 'func';
$foo = func( $bar );
```
the `use Module` line doesn't add anything of value to the documentation.

This changeset adds a new option, `match_boiler_barrier`, which takes a regular expression matching a line separating boilerplate from code that should remain.  If `remove_boiler` is set, and `match_boiler_barrier = BARRIER$`
```
use strict;
use warnings;
use Module 'func';
# BOILER BARRIER

$foo = func( $bar );
```
becomes
```
$foo = func( $bar );
```

To be honest, I'm not keen on the name of the option, `match_boiler_barrier`.